### PR TITLE
add fetch-depth to checkout step for NX

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -57,6 +57,7 @@ jobs:
 
           AFFECTED_PROJECTS=$(npx nx show projects --affected --projects "apps/*" --json)
 
+          echo "Affected Projects are: $AFFECTED_PROJECTS"
           echo "affected_projects=$AFFECTED_PROJECTS" >> $GITHUB_OUTPUT
 
       - name: Set matrix
@@ -107,6 +108,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install cosign
         if: github.event_name != 'pull_request'

--- a/apps/api/build/package/Dockerfile
+++ b/apps/api/build/package/Dockerfile
@@ -6,28 +6,28 @@ ARG UID=1001
 
 RUN apk update \
   && apk add --no-cache \
-    tzdata \
+  tzdata \
   && update-ca-certificates \
   && adduser \
-    --disabled-password \
-    --gecos "" \
-    --shell "/sbin/nologin" \
-    --no-create-home \
-    --uid "${UID}" \
-    "follytics"
+  --disabled-password \
+  --gecos "" \
+  --shell "/sbin/nologin" \
+  --no-create-home \
+  --uid "${UID}" \
+  "follytics"
 
 RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=bind,source=apps/api/go.mod,target=go.mod \
-    --mount=type=bind,source=apps/api/go.sum,target=go.sum \
-    go mod download
+  --mount=type=cache,target=/root/.cache/go-build \
+  --mount=type=bind,source=apps/api/go.mod,target=go.mod \
+  --mount=type=bind,source=apps/api/go.sum,target=go.sum \
+  go mod download
 
 COPY apps/api .
 COPY follytics.example.yaml follytics.yaml
 
 RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 GOOS=linux go build -v -o follytics cmd/follytics/follytics.go
+  --mount=type=cache,target=/root/.cache/go-build \
+  CGO_ENABLED=0 GOOS=linux go build -v -o follytics cmd/follytics/follytics.go
 
 FROM scratch
 


### PR DESCRIPTION
Add `fetch-depth: 0` to the `actions/checkout` step in the `detect-affected` job to ensure the correct context for NX. This allows NX to properly detect changes by fetching the full git history.
