### PR TITLE
override base for NX affected command

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -57,7 +57,12 @@ jobs:
         run: |
           set -euo pipefail
 
-          AFFECTED_PROJECTS=$(npx nx show projects --affected --projects "apps/*" --json)
+          NX_BASE=main
+          if [[ $GITHUB_REF == 'refs/heads/main' ]]; then
+            NX_BASE="HEAD^1"
+          fi
+
+          AFFECTED_PROJECTS=$(npx nx show projects --affected --projects "apps/*" --json --base="$NX_BASE")
 
           echo "Affected Projects are: $AFFECTED_PROJECTS"
           echo "affected_projects=$AFFECTED_PROJECTS" >> $GITHUB_OUTPUT

--- a/apps/api/project.json
+++ b/apps/api/project.json
@@ -5,9 +5,6 @@
   "sourceRoot": "apps/api",
   "tags": [],
   "targets": {
-    "tidy": {
-      "executor": "@nx-go/nx-go:tidy"
-    },
     "build": {
       "executor": "@nx-go/nx-go:build",
       "options": {
@@ -51,6 +48,9 @@
         "linter": "golangci-lint",
         "args": ["run", "--config=../../.golangci.yaml", "--fix"]
       }
+    },
+    "tidy": {
+      "executor": "@nx-go/nx-go:tidy"
     },
     "swag": {
       "executor": "@follytics/nx-helpers:swag",


### PR DESCRIPTION
Change the base of the NX affected command to `HEAD^1` on the main branch to correctly detect the differences.